### PR TITLE
Discard stdout and stderr of cron

### DIFF
--- a/definitions/disk-monitor.rb
+++ b/definitions/disk-monitor.rb
@@ -29,7 +29,7 @@ define :disk_monitor, :template => "alert.sh.erb", :bin_path => "/usr/local/bin"
   cron "disk-alert-#{options[:alert_level]}" do
     minute options[:cron_frequency]
     user options[:user]
-    command options[:bin]
+    command options[:bin] + " > /dev/null 2>&1"
   end
 
 end


### PR DESCRIPTION
What
-----------
Discard stderr and stdout of cron

Why
-----------
```
By default cron jobs sends a email to the user account executing the cronjob. If this is not needed put the following command At the end of the cron job line .

>/dev/null 2>&1
```

Deploy Plan
-----------
Do `git submodule update --remote disk-monitor` in https://github.com/sportngin/opsworks-site-cookbooks

Rollback Plan
-------------
To roll back this change, revert the merge with `git revert -m 1 MERGE_SHA` and perform another deploy.

URLs
----

QA Plan
-------
- [ ] SSH to clare-accounting staging
- [ ] `sudo less /var/spool/cron/root`
- [ ] `> /dev/null 2>&1` should be added for the alert crons